### PR TITLE
Fix parsing with dateTime'

### DIFF
--- a/src/Text/XML/XSD/DateTime.hs
+++ b/src/Text/XML/XSD/DateTime.hs
@@ -24,7 +24,7 @@ module Text.XML.XSD.DateTime
        ) where
 
 import           Prelude(Show(..), Read(..), Eq(..), Ord(..), Num(..), Int, Integer, String, (&&), (||), read, fromIntegral, realToFrac)
-import           Control.Applicative (pure, (<$>), (*>), (<|>))
+import           Control.Applicative (pure, (<$>), (*>), (<*), (<|>))
 import           Control.Monad (Monad(..), when)
 import           Control.Lens(Iso', Prism', _Left, _Right, iso, prism', from, isn't, (#), (^?))
 import           Data.Attoparsec.Text(Parser, char, digit, parseOnly, endOfInput, takeWhile)

--- a/src/Text/XML/XSD/DateTime.hs
+++ b/src/Text/XML/XSD/DateTime.hs
@@ -269,7 +269,7 @@ dateTime' ::
   Text
   -> Either String DateTime
 dateTime' =
-  parseOnly (parseDateTime <|> fail "bad date time")
+  parseOnly (parseDateTime <* endOfInput <|> fail "bad date time")
 
 buildSeconds ::
   Pico

--- a/xsd.cabal
+++ b/xsd.cabal
@@ -30,6 +30,7 @@ library
                       , text >= 1.0
                       , time >= 1.2.0.3
                       , lens >= 4
+                      , filepath >= 1.3
 
   ghc-options:
                       -Wall


### PR DESCRIPTION
Before, dateTime' accepted obviously wrong XsdDateTimes like "2015-08-26T14:09:57Z+02:00"  which resulted in something like "2015-08-26T14:09:57Z". After my patches, it will fail on input like this.
